### PR TITLE
Update mod managers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you know of any other sites/links I haven't added, make a pull request!
 
 ## Software
 ### Mod Loaders
-- [r2modman](https://r2modman.net)
+- [R2modman](https://r2modman.net)
 - [Thunderstore](https://thunderstore.io/c/webfishing/)
 - [Hook, Line, & Sinker](https://hooklinesinker.lol/) - (No longer supported)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ If you know of any other sites/links I haven't added, make a pull request!
 
 ## Software
 ### Mod Loaders
-- [Hook, Line, & Sinker](https://hooklinesinker.lol/) - The comprehensive mod manager for WEBFISHING using GDWeave.
+- [r2modman](https://r2modman.net)
 - [Thunderstore](https://thunderstore.io/c/webfishing/)
+- [Hook, Line, & Sinker](https://hooklinesinker.lol/) - (No longer supported)
 
 --------------------
 


### PR DESCRIPTION
- Updated mod managers list to mark HLS as unsupported
- Added link to r2modman for managing webfishing mods